### PR TITLE
Add Windows build script and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Project specific
+chat_config.json
+trading_config.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # TelegramCopier
-Er kopiert Signale von Telegram zu MT5
+
+Er kopiert Signale von Telegram zu MT5.
+
+## Windows-EXE erstellen
+
+Mit dem Skript `build_windows_exe.bat` kannst du unter Windows eine ausführbare Datei erstellen. Du benötigst dafür eine 64-Bit-Python-Installation (empfohlen wird Python 3.11), weil PyInstaller die Abhängigkeiten direkt aus der installierten Umgebung einsammelt.
+
+1. Lade dieses Repository auf deinen Windows-Rechner herunter und öffne eine Eingabeaufforderung im Projektordner.
+2. Führe das Skript `build_windows_exe.bat` per Doppelklick oder mit `build_windows_exe.bat` in der Eingabeaufforderung aus.
+3. Das Skript legt automatisch eine virtuelle Umgebung an, installiert die benötigten Pakete (inklusive PyInstaller) und baut anschließend das Projekt.
+4. Die fertige Anwendung findest du danach im Ordner `dist\TelegramCopier`. Die Datei `TelegramCopier.exe` kannst du direkt starten oder an einen anderen Ort kopieren.
+
+> Hinweis: Beim ersten Start der EXE werden die Dateien `trading_config.json` und `chat_config.json` im gleichen Verzeichnis erzeugt. Bewahre sie zusammen mit der EXE auf, wenn du das Programm verschieben möchtest.
+
+Wenn du Anpassungen an den PyInstaller-Optionen vornehmen möchtest (z.B. `--onefile` für eine einzelne EXE), kannst du die entsprechende Zeile im Batch-Skript anpassen.

--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -1,0 +1,69 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM ---------------------------------------------------------------
+REM  Build-Skript für TelegramCopier (Windows)
+REM  Erstellt eine virtuelle Umgebung und packt die App mit PyInstaller
+REM ---------------------------------------------------------------
+
+cd /d "%~dp0"
+
+set VENV_DIR=.venv
+if not exist "%VENV_DIR%" (
+    echo [INFO] Erstelle virtuelle Umgebung in %VENV_DIR% ...
+    py -3 -m venv "%VENV_DIR%"
+    if errorlevel 1 (
+        echo [FEHLER] Virtuelle Umgebung konnte nicht erstellt werden.
+        exit /b 1
+    )
+)
+
+call "%VENV_DIR%\Scripts\activate.bat"
+if errorlevel 1 (
+    echo [FEHLER] Virtuelle Umgebung konnte nicht aktiviert werden.
+    exit /b 1
+)
+
+echo [INFO] Aktualisiere pip ...
+python -m pip install --upgrade pip >nul
+if errorlevel 1 (
+    echo [FEHLER] pip konnte nicht aktualisiert werden.
+    exit /b 1
+)
+
+echo [INFO] Installiere Projekt-Abhaengigkeiten ...
+pip install -r requirements.windows.txt >nul
+if errorlevel 1 (
+    echo [FEHLER] Anforderungen konnten nicht installiert werden.
+    exit /b 1
+)
+
+echo [INFO] Installiere PyInstaller ...
+pip install "pyinstaller>=6.3" >nul
+if errorlevel 1 (
+    echo [FEHLER] PyInstaller konnte nicht installiert werden.
+    exit /b 1
+)
+
+echo [INFO] Baue TelegramCopier.exe ...
+pyinstaller TelegramCopier_Windows.py ^
+    --name TelegramCopier ^
+    --noconsole ^
+    --onedir ^
+    --clean ^
+    --collect-all telethon ^
+    --collect-all MetaTrader5
+
+if errorlevel 1 (
+    echo [FEHLER] PyInstaller hat den Build mit einem Fehler beendet.
+    exit /b 1
+)
+
+echo.
+echo [FERTIG] Die Anwendung befindet sich im Ordner dist\TelegramCopier.
+echo           Du kannst die EXE-Datei zusammen mit den generierten
+
+echo           Konfigurationsdateien auf einen Zielrechner kopieren.
+
+echo.
+endlocal


### PR DESCRIPTION
## Summary
- add a Windows batch script that builds the TelegramCopier GUI into an executable with PyInstaller
- document the Windows build workflow in the README so the EXE can be created locally
- ensure generated configuration files stay out of version control via .gitignore

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d00b4d87748332b1e635036e6c0966