### PR TITLE
Fix loading chats while disconnected

### DIFF
--- a/TelegramCopier_Windows.py
+++ b/TelegramCopier_Windows.py
@@ -593,7 +593,12 @@ class MultiChatTradingBot:
         if not self.client:
             self.log("Telegram-Konfiguration fehlt. Chats können nicht geladen werden.", "ERROR")
             return chats_data
+
         try:
+            # Verbindung sicherstellen – iter_dialogs schlägt sonst mit "disconnected" fehl
+            if not self.client.is_connected():
+                await self.client.connect()
+
             async for dialog in self.client.iter_dialogs(limit=200):
                 chat_info = {
                     'id': dialog.id,
@@ -801,11 +806,11 @@ class TradingGUI:
 
     def load_chats(self):
         """Chats laden (async wrapper)"""
+
         def run_async():
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             try:
-                loop.run_until_complete(self.bot.load_all_chats())
                 chats = loop.run_until_complete(self.bot.load_all_chats())
                 self.root.after(0, lambda: self.update_chat_list(chats))
             except Exception as e:


### PR DESCRIPTION
## Summary
- ensure the Telethon client is connected before iterating dialogs when loading chats
- simplify the chat loading helper so chats are only fetched once per request

## Testing
- python -m compileall TelegramCopier_Windows.py

------
https://chatgpt.com/codex/tasks/task_e_68d02cd88e408332bb90b290a04adcd3