### PR TITLE
Fix Tk font configuration causing startup error

### DIFF
--- a/TelegramCopier_Windows.py
+++ b/TelegramCopier_Windows.py
@@ -1011,9 +1011,14 @@ class TradingGUI:
         }
 
         self.root.configure(bg=base_bg)
-        self.root.option_add('*Font', 'Segoe UI 10')
-        self.root.option_add('*TCombobox*Listbox.Font', 'Segoe UI 10')
-        self.root.option_add('*TEntry.Font', 'Segoe UI 10')
+        # Fonts with spaces in the family name must be wrapped in braces so that
+        # Tk does not interpret the second word ("UI") as the font size.  When
+        # this happens Tk raises the error "expected integer but got UI" during
+        # startup, resulting in a blank window for the user.  By adding braces
+        # we ensure the whole family name is passed correctly.
+        self.root.option_add('*Font', '{Segoe UI} 10')
+        self.root.option_add('*TCombobox*Listbox.Font', '{Segoe UI} 10')
+        self.root.option_add('*TEntry.Font', '{Segoe UI} 10')
 
         # Standard-Schriftarten über die Tk-Font-Objekte setzen, damit Tk sie korrekt
         # interpretiert und alle Widgets (inkl. ttk) konsistent aktualisiert werden.


### PR DESCRIPTION
## Summary
- wrap the Segoe UI font declarations in braces when configuring Tk default fonts
- add inline documentation explaining the startup failure "expected integer but got UI"

## Testing
- not run (GUI application)


------
https://chatgpt.com/codex/tasks/task_e_68d05ea3b10083329d2c5beedaf6fd80