### PR TITLE
Request login code when loading chats

### DIFF
--- a/TelegramCopier_Windows.py
+++ b/TelegramCopier_Windows.py
@@ -757,10 +757,11 @@ class MultiChatTradingBot:
 
         try:
             authorized = await self.ensure_authorized(
-                request_code=False,
+                request_code=True,
                 notify_gui=True,
                 message=(
-                    "Telegram-Login erforderlich. Chats können erst nach Eingabe des Login-Codes geladen werden."
+                    "Telegram-Login erforderlich. Ein neuer Login-Code wurde angefordert. "
+                    "Bitte geben Sie ihn ein, um die Chats zu laden."
                 )
             )
             if not authorized:


### PR DESCRIPTION
## Summary
- request a new Telegram login code when the user tries to load chats while not yet authorized
- update the login prompt message so it explains that a new code was requested

## Testing
- python -m compileall TelegramCopier_Windows.py

------
https://chatgpt.com/codex/tasks/task_e_68d063b2e00883329d9ef43513679399