### PR TITLE
Add MT5 configuration UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Mit dem Skript `build_windows_exe.bat` kannst du unter Windows eine ausführbare
 > Hinweis: Beim ersten Start der EXE werden die Dateien `trading_config.json` und `chat_config.json` im gleichen Verzeichnis erzeugt. Bewahre sie zusammen mit der EXE auf, wenn du das Programm verschieben möchtest.
 
 Wenn du Anpassungen an den PyInstaller-Optionen vornehmen möchtest (z.B. `--onefile` für eine einzelne EXE), kannst du die entsprechende Zeile im Batch-Skript anpassen.
+
+## MT5-Verbindung konfigurieren
+
+1. Starte die Anwendung und öffne den Tab **„Bot Einstellungen“**.
+2. Im Abschnitt **„MetaTrader 5 Verbindung“** kannst du Login (Kontonummer), Passwort, Server und optional den Pfad zur `terminal64.exe` deines MetaTrader-5-Terminals hinterlegen.
+3. Klicke auf **„Zugangsdaten speichern“**, damit die Informationen in `trading_config.json` abgelegt und vom Bot übernommen werden.
+4. Über **„Verbindung testen“** prüfst du sofort, ob die MT5-Schnittstelle erreichbar ist. Bei Erfolg kannst du den Demo-Modus deaktivieren – auch ein MT5-Demokonto lässt sich so nutzen.
+
+> Hinweis: Ohne installiertes MetaTrader5-Python-Modul bleibt der Live-Modus deaktiviert. Installiere MetaTrader 5 inklusive des Python-Pakets `MetaTrader5`, damit die Verbindung funktioniert.


### PR DESCRIPTION
## Summary
- add MetaTrader 5 credential inputs and helpers to the bot settings tab so users can store login, password, server and terminal path
- wire the GUI to update MT5 credentials, provide a connection test button and allow selecting the terminal executable
- document the MT5 setup workflow in the README for easier onboarding

## Testing
- python -m compileall TelegramCopier_Windows.py

------
https://chatgpt.com/codex/tasks/task_e_68d0780477b883328c9194e8119d68b9