### PR TITLE
Improve MT5 status feedback in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Wenn du Anpassungen an den PyInstaller-Optionen vornehmen möchtest (z.B. `--one
 ## MT5-Verbindung konfigurieren
 
 1. Starte die Anwendung und öffne den Tab **„Bot Einstellungen“**.
-2. Trage dort Login (Kontonummer), Passwort und Server deines MetaTrader-5-Kontos – Demo oder Live – ein. Optional kannst du den Pfad zur `terminal64.exe` deines Terminals hinterlegen.
-3. Speichere die Eingaben mit **„Zugangsdaten speichern“**. Die Daten landen in `trading_config.json` und werden direkt an den Bot übergeben.
-4. Mit **„Verbindung testen“** prüfst du sofort, ob die MT5-Schnittstelle erreichbar ist und der Bot Orders platzieren kann. Bei Erfolg zeigt der Dialog zusätzliche Konto-Informationen (Login, Balance, Währung), damit du sicher weißt, welches Konto verbunden ist.
-5. Der Statusbereich im Tab informiert darüber, ob die Zugangsdaten vollständig sind und blendet nach einem erfolgreichen Test die aktuelle Kontoübersicht ein.
+2. Trage dort Login (Kontonummer), Passwort und Server deines gewünschten MetaTrader-5-Kontos ein. Optional kannst du den Pfad zur `terminal64.exe` des Terminals hinterlegen, falls du mehrere Installationen nutzt.
+3. Speichere die Eingaben mit **„Zugangsdaten speichern“**. Die Daten landen in `trading_config.json`, damit der Bot sie beim nächsten Start automatisch verwendet.
+4. Öffne dein MetaTrader-5-Terminal, melde dich im gewünschten Konto an und klicke anschließend auf **„Verbindung testen“**. Der Bot prüft damit die Schnittstelle und zeigt bei Erfolg Konto-Informationen (Login, Balance, Währung), damit du siehst, welches Konto angebunden ist.
+5. Der Statusbereich im Tab informiert darüber, ob die Zugangsdaten vollständig sind. Nach einem erfolgreichen Test erscheint dort die aktuelle Kontoübersicht, bis du die Daten änderst.
+6. Falls das Python-Modul `MetaTrader5` noch fehlt, kannst du die Felder trotzdem ausfüllen und den Terminalpfad auswählen. Installiere das Paket später (z. B. mit `pip install MetaTrader5`) und starte die Anwendung neu, um die Verbindung zu aktivieren.
 
 > Hinweis: Ohne installiertes MetaTrader5-Python-Modul bleibt der Live-Modus deaktiviert. Die Felder kannst du trotzdem ausfüllen; der Status erinnert dich daran, das Paket nachzuinstallieren. Installiere MetaTrader 5 inklusive des Python-Pakets `MetaTrader5`, damit die Verbindung funktioniert.

--- a/TelegramCopier_Windows.py
+++ b/TelegramCopier_Windows.py
@@ -3003,14 +3003,18 @@ class TradingGUI:
 
     def browse_mt5_path(self):
         """Dateidialog zum Auswählen des MT5-Terminals öffnen."""
-        if not MT5_AVAILABLE:
-            message = "MetaTrader5-Python-Modul ist nicht verfügbar."
+        module_missing = not MT5_AVAILABLE
+        if module_missing:
+            message = (
+                "MetaTrader5-Python-Modul ist nicht verfügbar. "
+                "Sie können den Terminalpfad trotzdem auswählen und speichern; "
+                "installieren Sie das Paket anschließend, um die Verbindung zu aktivieren."
+            )
             self.log_message(message)
             try:
-                messagebox.showwarning("MT5 nicht verfügbar", message)
+                messagebox.showwarning("MT5-Modul nicht installiert", message)
             except Exception:
                 pass
-            return
 
         try:
             selected = filedialog.askopenfilename(
@@ -3036,7 +3040,13 @@ class TradingGUI:
 
         self.save_mt5_credentials(silent=True)
         self._refresh_mt5_status_display()
-        self.log_message("MT5-Terminalpfad aktualisiert.")
+        if module_missing:
+            self.log_message(
+                "MT5-Terminalpfad gespeichert. Installieren Sie das MetaTrader5-Python-Modul, "
+                "um die Verbindung testen zu können."
+            )
+        else:
+            self.log_message("MT5-Terminalpfad aktualisiert.")
 
     def _add_trading_var_trace(self, key: str, var: tk.Variable, caster):
         """Trace für Trading-Variablen registrieren."""


### PR DESCRIPTION
## Summary
- add a connection status card and hint label to the MT5 settings tab and keep them in sync with the current credentials
- centralize MT5 status updates so saving credentials, browsing the terminal path and connection tests show clear hints and account summaries
- mention the in-app status overview in the MT5 configuration steps
- keep the MT5 credential form usable even when the MetaTrader5 module is missing and clarify the guidance shown in the UI and README

## Testing
- python -m compileall TelegramCopier_Windows.py

------
https://chatgpt.com/codex/tasks/task_e_68d0780477b883328c9194e8119d68b9