### PR TITLE
fix: align Windows setup with NumPy 1.x requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Er kopiert Signale von Telegram zu MT5.
 
+### Windows (Ein-Klick-Start)
+1) In GitHub Desktop **Fetch/Pull**.
+2) Im Explorer `scripts\fix_mt5_numpy.bat` **Doppelklicken**.
+   - Erzwingt NumPy 1.26.4 (kompatibel mit MetaTrader5 5.0.45),
+   - installiert Anforderungen,
+   - startet `TelegramCopier_Windows.py` (Onboarding-Popup erscheint).
+
 ## Windows-EXE erstellen
 
 Mit dem Skript `build_windows_exe.bat` kannst du unter Windows eine ausführbare Datei erstellen. Du benötigst dafür eine 64-Bit-Python-Installation (empfohlen wird Python 3.11), weil PyInstaller die Abhängigkeiten direkt aus der installierten Umgebung einsammelt.

--- a/TelegramCopier_Windows.py
+++ b/TelegramCopier_Windows.py
@@ -17,6 +17,21 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Optional, Dict, List, Awaitable
 
+# >>> numpy/mt5 guard
+try:
+    import numpy as _np
+    _major = int(_np.__version__.split(".")[0])
+    if _major >= 2:
+        raise RuntimeError(
+            f"NumPy {_np.__version__} erkannt. MetaTrader5 benoetigt NumPy 1.x. "
+            "Bitte starte 'scripts\\fix_mt5_numpy.bat' oder installiere: "
+            "pip uninstall -y numpy && pip install numpy==1.26.4"
+        )
+except Exception as _e:
+    print("[startup]", _e)
+    raise
+# <<< numpy/mt5 guard
+
 # ---- optionale Abhängigkeit: MetaTrader5 (nur für Windows verfügbar) ----
 try:
     import MetaTrader5 as mt5  # noqa: F401

--- a/requirements.windows.txt
+++ b/requirements.windows.txt
@@ -1,2 +1,10 @@
--r requirements.txt
+numpy==1.26.4
 MetaTrader5==5.0.45
+telethon
+python-dotenv
+pyasn1
+rsa
+requests
+urllib3
+idna
+charset-normalizer

--- a/scripts/fix_mt5_numpy.bat
+++ b/scripts/fix_mt5_numpy.bat
@@ -1,0 +1,17 @@
+@echo off
+setlocal
+cd /d %~dp0\..
+if not exist .venv (
+  python -m venv .venv
+)
+call .venv\Scripts\activate
+python -m pip install --upgrade pip
+rem harte Korrektur falls NumPy 2.x vorhanden ist
+pip uninstall -y numpy >nul 2>&1
+pip install --no-cache-dir numpy==1.26.4
+pip install --no-cache-dir -r requirements.windows.txt
+echo.
+echo ✅ Abhaengigkeiten installiert (NumPy 1.26.4 / MetaTrader5 5.0.45).
+echo Starte App...
+python TelegramCopier_Windows.py
+pause


### PR DESCRIPTION
## Summary
- pin numpy 1.26.4 in the Windows requirements to match MetaTrader5 5.0.45
- add a fix_mt5_numpy.bat helper for one-click Windows setup and launch
- guard the MetaTrader5 import against NumPy 2.x and document the new workflow in the README

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d1830fe1d883328530fd8d56e71f74