### PR TITLE
fix: enforce Windows onboarding and venv usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,12 @@ __marimo__/
 # Project specific
 chat_config.json
 trading_config.json
+tg_session*
+*.session
+*.session-journal
+*.db
+.venv/
+dist/
+build/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Er kopiert Signale von Telegram zu MT5.
    - installiert Anforderungen,
    - startet `TelegramCopier_Windows.py` (Onboarding-Popup erscheint).
 
+### Windows Quickstart
+- **Erststart / Setup:** `scripts\fix_mt5_numpy.bat`
+- **Normaler Start:** `scripts\start_windows.bat`
+- **Setup erzwingen (Onboarding-Popup erneut):** `scripts\force_setup.bat`
+
 ## Windows-EXE erstellen
 
 Mit dem Skript `build_windows_exe.bat` kannst du unter Windows eine ausführbare Datei erstellen. Du benötigst dafür eine 64-Bit-Python-Installation (empfohlen wird Python 3.11), weil PyInstaller die Abhängigkeiten direkt aus der installierten Umgebung einsammelt.

--- a/scripts/check_gui.bat
+++ b/scripts/check_gui.bat
@@ -1,0 +1,6 @@
+@echo off
+setlocal
+cd /d %~dp0\..
+if not exist .venv ( python -m venv .venv )
+.\.venv\Scripts\python.exe -c "import tkinter as tk; print('OK: tkinter available')"
+pause

--- a/scripts/fix_mt5_numpy.bat
+++ b/scripts/fix_mt5_numpy.bat
@@ -4,14 +4,13 @@ cd /d %~dp0\..
 if not exist .venv (
   python -m venv .venv
 )
-call .venv\Scripts\activate
-python -m pip install --upgrade pip
-rem harte Korrektur falls NumPy 2.x vorhanden ist
-pip uninstall -y numpy >nul 2>&1
-pip install --no-cache-dir numpy==1.26.4
-pip install --no-cache-dir -r requirements.windows.txt
+rem immer innerhalb der venv installieren
+.\.venv\Scripts\python.exe -m pip install --upgrade pip
+rem harte Korrektur: falls NumPy 2.x vorhanden, neu installieren
+.\.venv\Scripts\python.exe -m pip uninstall -y numpy 2>nul
+.\.venv\Scripts\python.exe -m pip install --no-cache-dir numpy==1.26.4
+.\.venv\Scripts\python.exe -m pip install --no-cache-dir -r requirements.windows.txt
 echo.
 echo ✅ Abhaengigkeiten installiert (NumPy 1.26.4 / MetaTrader5 5.0.45).
 echo Starte App...
-python TelegramCopier_Windows.py
-pause
+call scripts\start_windows.bat %*

--- a/scripts/force_setup.bat
+++ b/scripts/force_setup.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal
+cd /d %~dp0\..
+rem env Variablen fuer diesen Prozess leeren, damit Popup NICHT skippt
+set TG_API_ID=
+set TG_API_HASH=
+set TG_TARGET=
+set FORWARD_TO=
+rem alte .env optional loeschen (auskommentieren, falls behalten gewuenscht)
+del /f /q .env 2>nul
+call scripts\start_windows.bat --setup

--- a/scripts/start_windows.bat
+++ b/scripts/start_windows.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+cd /d %~dp0\..
+if not exist .venv (
+  python -m venv .venv
+)
+rem immer die venv-Python verwenden
+.\.venv\Scripts\python.exe -m pip install --upgrade pip >nul 2>&1
+.\.venv\Scripts\python.exe TelegramCopier_Windows.py %*
+pause


### PR DESCRIPTION
## Summary
- add numpy/MetaTrader5 guard and onboarding bootstrap to the Windows launcher
- add Windows helper scripts to enforce virtualenv usage and numpy 1.26.4 pinning
- document the Windows quickstart flow and ignore local session artifacts

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d18c40e3ac8332b93b518f29d1063d