### PR TITLE
fix: improve Windows UI bootstrap and add UI scripts

### DIFF
--- a/scripts/debug_start.bat
+++ b/scripts/debug_start.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+cd /d %~dp0\..
+echo === DEBUG ENV ===
+where python
+if not exist .venv ( echo (creating venv) & python -m venv .venv )
+.\.venv\Scripts\python.exe -V
+.\.venv\Scripts\python.exe -c "import sys,platform;print('platform', platform.platform());import tkinter as tk;print('tk OK')"
+.\.venv\Scripts\python.exe -c "import numpy,MetaTrader5 as mt5;print('numpy',numpy.__version__);print('mt5 import OK')"
+echo === RUN APP ===
+.\.venv\Scripts\python.exe TelegramCopier_Windows.py --setup --ui
+echo.
+pause

--- a/scripts/start_ui_only.bat
+++ b/scripts/start_ui_only.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+cd /d %~dp0\..
+if not exist .venv ( python -m venv .venv )
+.\.venv\Scripts\python.exe -m pip install --upgrade pip >nul 2>&1
+.\.venv\Scripts\python.exe -c "from ui.app import run_app; run_app({})"
+echo.
+pause

--- a/scripts/start_windows_ui.bat
+++ b/scripts/start_windows_ui.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+cd /d %~dp0\..
+if not exist .venv ( python -m venv .venv )
+.\.venv\Scripts\python.exe -m pip install --upgrade pip >nul 2>&1
+rem UI direkt starten, egal was die Umgebung hat
+.\.venv\Scripts\python.exe TelegramCopier_Windows.py --ui
+echo.
+pause

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,0 +1,81 @@
+"""Bootstrap module for launching the TelegramCopier UI."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def run_app(session: Optional[Dict[str, Any]] = None) -> None:
+    """Start the desktop UI.
+
+    Parameters
+    ----------
+    session:
+        Optional session information. Currently unused, but reserved for
+        compatibility with other launchers.
+    """
+
+    # Avoid circular imports by importing lazily within the function.
+    from TelegramCopier_Windows import (
+        ConfigManager,
+        SetupAssistant,
+        TradingGUI,
+        check_first_run,
+    )
+    import tkinter as tk
+
+    _ = session  # suppress "unused" linter warnings while keeping the signature stable
+
+    try:
+        config_manager = ConfigManager()
+        cfg = config_manager.load_config()
+
+        def _has_required_credentials(config: Dict) -> bool:
+            telegram_cfg = config.get('telegram', {})
+            required_fields = ('api_id', 'api_hash', 'phone')
+            return all(telegram_cfg.get(field) for field in required_fields)
+
+        def _launch_setup_wizard() -> bool:
+            root = tk.Tk()
+            root.withdraw()
+            setup = SetupAssistant(root)
+            setup.show_setup_dialog()
+            root.mainloop()
+            root.destroy()
+
+            if not setup.config_saved:
+                print("Setup abgebrochen. Anwendung wird beendet.")
+                return False
+
+            return True
+
+        setup_completed = False
+
+        if check_first_run():
+            if not _launch_setup_wizard():
+                return
+
+            setup_completed = True
+            cfg = config_manager.load_config()
+
+        telegram_cfg = cfg.get('telegram', {})
+        missing_credentials = not _has_required_credentials(cfg)
+
+        if not setup_completed and (telegram_cfg.get('prompt_credentials_on_start') or missing_credentials):
+            if not _launch_setup_wizard():
+                return
+
+            setup_completed = True
+            cfg = config_manager.load_config()
+            telegram_cfg = cfg.get('telegram', {})
+            missing_credentials = not _has_required_credentials(cfg)
+
+        if missing_credentials:
+            print("Keine gültigen API-Zugangsdaten vorhanden. Anwendung wird beendet.")
+            return
+
+        app = TradingGUI(cfg)
+        app.run()
+    except Exception as exc:  # pragma: no cover - defensive error reporting
+        print(f"Fehler beim Starten der Anwendung: {exc}")
+        input("Drücken Sie Enter zum Beenden...")


### PR DESCRIPTION
## Summary
- add CLI bootstrap helpers so `TelegramCopier_Windows.py` can start the UI safely and honour the `--ui` flag
- extract the GUI launch routine into `ui/app.py` so other launchers can reuse it
- add Windows batch helpers to start the UI directly or run debug diagnostics

## Testing
- python -m compileall TelegramCopier_Windows.py ui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c57f1e6c8332a55949d164a0beaa