### PR TITLE
feat(ui): force onboarding before UI and open app on Settings tab; start_windows_ui.bat uses --setup

### DIFF
--- a/scripts/start_windows_ui.bat
+++ b/scripts/start_windows_ui.bat
@@ -3,7 +3,6 @@ setlocal
 cd /d %~dp0\..
 if not exist .venv ( python -m venv .venv )
 .\.venv\Scripts\python.exe -m pip install --upgrade pip >nul 2>&1
-rem UI direkt starten, egal was die Umgebung hat
-.\.venv\Scripts\python.exe TelegramCopier_Windows.py --ui
-echo.
+rem Onboarding erzwingen, danach normale App starten
+.\.venv\Scripts\python.exe TelegramCopier_Windows.py --setup
 pause

--- a/ui/app.py
+++ b/ui/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 
-def run_app(session: Optional[Dict[str, Any]] = None) -> None:
+def run_app(session: Optional[Dict[str, Any]] = None, initial_page: str = "dashboard") -> None:
     """Start the desktop UI.
 
     Parameters
@@ -13,6 +13,8 @@ def run_app(session: Optional[Dict[str, Any]] = None) -> None:
     session:
         Optional session information. Currently unused, but reserved for
         compatibility with other launchers.
+    initial_page:
+        Name of the page that should be shown first when the UI opens.
     """
 
     # Avoid circular imports by importing lazily within the function.
@@ -75,6 +77,7 @@ def run_app(session: Optional[Dict[str, Any]] = None) -> None:
             return
 
         app = TradingGUI(cfg)
+        app.set_initial_page(initial_page)
         app.run()
     except Exception as exc:  # pragma: no cover - defensive error reporting
         print(f"Fehler beim Starten der Anwendung: {exc}")


### PR DESCRIPTION
## Summary
- update the Windows launcher script to always pass --setup so onboarding runs before the UI
- allow the desktop UI launcher to select an initial page and make TradingGUI honour the requested page by defaulting to the settings tab
- always start the UI after onboarding from TelegramCopier_Windows.py and remove the --ui shortcut

## Testing
- python -m compileall ..

------
https://chatgpt.com/codex/tasks/task_e_68d1c9f47a2c8332af95dd8253a7036a