### PR TITLE
fix(start): show onboarding (GUI) or console fallback; always open UI after setup; verbose launcher

### DIFF
--- a/scripts/debug_start.bat
+++ b/scripts/debug_start.bat
@@ -1,13 +1,13 @@
-@echo off
+@echo on
 setlocal
 cd /d %~dp0\..
-echo === DEBUG ENV ===
-where python
-if not exist .venv ( echo (creating venv) & python -m venv .venv )
+if not exist .venv ( python -m venv .venv )
 .\.venv\Scripts\python.exe -V
-.\.venv\Scripts\python.exe -c "import sys,platform;print('platform', platform.platform());import tkinter as tk;print('tk OK')"
-.\.venv\Scripts\python.exe -c "import numpy,MetaTrader5 as mt5;print('numpy',numpy.__version__);print('mt5 import OK')"
-echo === RUN APP ===
-.\.venv\Scripts\python.exe TelegramCopier_Windows.py --setup --ui
-echo.
+.\.venv\Scripts\python.exe -c "import tkinter as tk; print('tkinter OK')"
+.\.venv\Scripts\python.exe -c "import numpy; print('numpy', numpy.__version__)"
+.\.venv\Scripts\python.exe -u -X faulthandler TelegramCopier_Windows.py --setup
+if exist logs\last_startup_error.log (
+  echo --- logs\last_startup_error.log ---
+  type logs\last_startup_error.log
+)
 pause

--- a/scripts/start_windows_ui.bat
+++ b/scripts/start_windows_ui.bat
@@ -1,8 +1,7 @@
-@echo off
+@echo on
 setlocal
 cd /d %~dp0\..
 if not exist .venv ( python -m venv .venv )
-.\.venv\Scripts\python.exe -m pip install --upgrade pip >nul 2>&1
-rem Onboarding erzwingen, danach normale App starten
-.\.venv\Scripts\python.exe TelegramCopier_Windows.py --setup
+.\.venv\Scripts\python.exe -u -X faulthandler TelegramCopier_Windows.py --setup
+echo ExitCode=%errorlevel%
 pause


### PR DESCRIPTION
## Summary
- add console fallback for onboarding that writes .env and environment variables
- wrap onboarding/UI startup in safe_main logging fatal errors to logs/last_startup_error.log
- update Windows launcher scripts to run setup with faulthandler and echo exit code

## Testing
- python -m compileall TelegramCopier_Windows.py

------
https://chatgpt.com/codex/tasks/task_e_68d1cd79d34083329bd1c5a82555591c