### PR TITLE
Force console onboarding fallback and guard GUI

### DIFF
--- a/scripts/start_windows_ui.bat
+++ b/scripts/start_windows_ui.bat
@@ -2,6 +2,5 @@
 setlocal
 cd /d %~dp0\..
 if not exist .venv ( python -m venv .venv )
-.\.venv\Scripts\python.exe -u -X faulthandler TelegramCopier_Windows.py --setup
-echo ExitCode=%errorlevel%
+.\.venv\Scripts\python.exe -u -X faulthandler TelegramCopier_Windows.py --setup --console-setup
 pause


### PR DESCRIPTION
## Summary
- enforce console onboarding when `--console-setup` is provided and only run the GUI wizard when the environment is not ready
- center and raise the onboarding window while validating it becomes visible within five seconds, with a console fallback if GUI setup fails
- call the Windows start script with `--console-setup` so new users can complete onboarding reliably

## Testing
- python -m py_compile TelegramCopier_Windows.py ui/onboarding.py


------
https://chatgpt.com/codex/tasks/task_e_68d28e1501e88332bd5eb0aaea11f901