### PR TITLE
feat(start): always show onboarding on every launch (--always-setup); reset .env & TG_*; add start_norma

### DIFF
--- a/scripts/start_normal.bat
+++ b/scripts/start_normal.bat
@@ -1,0 +1,6 @@
+@echo on
+setlocal
+cd /d %~dp0\..
+if not exist .venv ( python -m venv .venv )
+.\.venv\Scripts\python.exe -u TelegramCopier_Windows.py
+pause

--- a/scripts/start_windows_ui.bat
+++ b/scripts/start_windows_ui.bat
@@ -2,5 +2,6 @@
 setlocal
 cd /d %~dp0\..
 if not exist .venv ( python -m venv .venv )
-.\.venv\Scripts\python.exe -u -X faulthandler TelegramCopier_Windows.py --setup --console-setup
+rem immer Wizard zeigen -> .env/Variablen werden im Code resettet
+.\.venv\Scripts\python.exe -u -X faulthandler TelegramCopier_Windows.py --always-setup
 pause


### PR DESCRIPTION
## Summary
- ensure the onboarding wizard can be forced with new flags, clearing .env and Telegram environment variables before running
- guard the skip path so onboarding always appears when requested and add a console-only override
- add Windows batch scripts to always run the setup flow or start normally without onboarding

## Testing
- `python -m compileall TelegramCopier_Windows.py`


------
https://chatgpt.com/codex/tasks/task_e_68d2ac24b4608332ba7a0c3e04db8478