### PR TITLE
Improve onboarding wizard with dark two-step flow

### DIFF
--- a/ui/onboarding.py
+++ b/ui/onboarding.py
@@ -1,376 +1,204 @@
-"""Tkinter-based onboarding wizard for Telegram Copier configuration."""
+# ui/onboarding.py
+import json, os, tkinter as tk
+from tkinter import ttk, messagebox
 
-from __future__ import annotations
+DARK_BG   = "#0f1217"
+CARD_BG   = "#151a22"
+TEXT_FG   = "#eef2f7"
+MUTED_FG  = "#8a94a6"
+ACCENT    = "#7c5cff"
+ACCENT2   = "#00d1ff"
 
-import tkinter as tk
-from tkinter import messagebox, ttk
-from pathlib import Path
-from typing import Dict, Optional
+CHAT_CFG = "chat_config.json"
 
-ACCENT_COLOR = "#4C8BF5"
-INACTIVE_COLOR = "#CBD5E1"
-BACKGROUND_COLOR = "#F8FAFC"
-TEXT_COLOR = "#0F172A"
-
-
-class _StepIndicator:
-    """Utility widget to display the wizard stepper."""
-
-    def __init__(self, master: tk.Widget, index: int, title: str) -> None:
-        self.frame = ttk.Frame(master)
-
-        self.canvas = tk.Canvas(
-            self.frame,
-            width=32,
-            height=32,
-            highlightthickness=0,
-            bd=0,
-            bg=BACKGROUND_COLOR,
-        )
-        self.circle_id = self.canvas.create_oval(4, 4, 28, 28, fill=INACTIVE_COLOR, outline="")
-        self.text_id = self.canvas.create_text(
-            16,
-            16,
-            text=str(index),
-            fill="white",
-            font=("Segoe UI", 10, "bold"),
-        )
-        self.canvas.pack()
-
-        self.label = ttk.Label(self.frame, text=title, font=("Segoe UI", 10, "bold"))
-        self.label.pack(pady=(4, 0))
-
-    def grid(self, **kwargs: object) -> None:
-        self.frame.grid(**kwargs)
-
-    def set_state(self, active: bool, completed: bool = False) -> None:
-        if active:
-            fill = ACCENT_COLOR
-            text_color = "white"
-        elif completed:
-            fill = ACCENT_COLOR
-            text_color = "white"
-        else:
-            fill = INACTIVE_COLOR
-            text_color = "white"
-        self.canvas.itemconfig(self.circle_id, fill=fill)
-        self.canvas.itemconfig(self.text_id, fill=text_color)
-
-
-class _StepConnector:
-    """Connector between wizard steps."""
-
-    def __init__(self, master: tk.Widget) -> None:
-        self.canvas = tk.Canvas(
-            master,
-            width=72,
-            height=6,
-            highlightthickness=0,
-            bd=0,
-            bg=BACKGROUND_COLOR,
-        )
-        self.line_id = self.canvas.create_line(
-            4, 3, 68, 3, fill=INACTIVE_COLOR, width=3, capstyle=tk.ROUND
-        )
-
-    def grid(self, **kwargs: object) -> None:
-        self.canvas.grid(**kwargs)
-
-    def set_state(self, active: bool) -> None:
-        color = ACCENT_COLOR if active else INACTIVE_COLOR
-        self.canvas.itemconfig(self.line_id, fill=color)
-
+def _load_known_chats():
+    if os.path.exists(CHAT_CFG):
+        try:
+            with open(CHAT_CFG, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                return data.get("known_chats", [])
+        except Exception:
+            pass
+    # Placeholder, falls nichts da ist
+    return [
+        {"title": "Premium Forex Signals", "username": "@PremiumForexSignals"},
+        {"title": "Gold Trading VIP", "username": "@GoldTradingVIP"},
+        {"title": "Crypto Signals Pro", "username": "@CryptoSignalsPro"},
+    ]
 
 class OnboardingTwoStep(tk.Toplevel):
-    def __init__(self, root: tk.Tk) -> None:
-        super().__init__(root)
-        self.result: Optional[Dict[str, str]] = None
-
-        self.title("Telegram Copier Onboarding")
-        self.configure(bg=BACKGROUND_COLOR)
+    def __init__(self, master):
+        super().__init__(master)
+        self.withdraw()
+        self.title("Onboarding")
+        self.configure(bg=DARK_BG)
         self.resizable(False, False)
-        self.transient(root)
-        self.grab_set()
-        self.protocol("WM_DELETE_WINDOW", self._cancel)
+        self.minsize(560, 520)
+        self.result = None
 
-        style = ttk.Style(self)
-        try:
-            style.theme_use("clam")
-        except tk.TclError:
-            pass
-        style.configure("TFrame", background=BACKGROUND_COLOR)
-        style.configure("TLabel", background=BACKGROUND_COLOR, foreground=TEXT_COLOR)
-        style.configure("TButton", font=("Segoe UI", 10))
-        style.configure("Accent.TButton", font=("Segoe UI", 10, "bold"))
+        # Styles
+        st = ttk.Style(self)
+        try: st.theme_use("clam")
+        except: pass
+        st.configure("Bg.TFrame", background=DARK_BG)
+        st.configure("Card.TFrame", background=CARD_BG)
+        st.configure("Title.TLabel", font=("Segoe UI", 22, "bold"),
+                    foreground=TEXT_FG, background=DARK_BG)
+        st.configure("H2.TLabel", font=("Segoe UI", 14, "bold"),
+                    foreground=TEXT_FG, background=CARD_BG)
+        st.configure("Text.TLabel", foreground=TEXT_FG, background=CARD_BG)
+        st.configure("Muted.TLabel", foreground=MUTED_FG, background=CARD_BG)
+        st.configure("Nav.TButton", padding=10)
+        st.map("Nav.TButton", background=[("active", CARD_BG)], foreground=[("!disabled", TEXT_FG)])
 
-        self.content = ttk.Frame(self, padding=20)
-        self.content.pack(fill="both", expand=True)
+        # Root Layout
+        rootf = ttk.Frame(self, style="Bg.TFrame", padding=16)
+        rootf.pack(fill="both", expand=True)
+        ttk.Label(rootf, text="ONBOARDING", style="Title.TLabel").pack(anchor="w", pady=(0,10))
 
-        self._create_stepper()
-        self._create_steps()
+        self.stepper = ttk.Frame(rootf, style="Bg.TFrame")
+        self.stepper.pack(fill="x", pady=(0,8))
+        self._build_stepper(self.stepper, active=1)
 
-        self._show_step(0)
+        self.container = ttk.Frame(rootf, style="Bg.TFrame")
+        self.container.pack(fill="both", expand=True)
 
-        # Sichtbarkeit/Position erzwingen
+        # Steps
+        self.api_id = tk.StringVar()
+        self.api_hash = tk.StringVar()
+        self.tg_target = tk.StringVar()
+
+        self.step1 = self._build_step1(self.container)   # API
+        self.step2 = self._build_step2(self.container)   # Chats
+        self.current = 1
+        self._show(1)
+
+        # Sichtbarkeit erzwingen
         self.update_idletasks()
         w, h = self.winfo_reqwidth(), self.winfo_reqheight()
         sw, sh = self.winfo_screenwidth(), self.winfo_screenheight()
         x, y = max(0, (sw - w)//2), max(0, (sh - h)//2)
         self.geometry(f"+{x}+{y}")
-        self.lift(); self.attributes("-topmost", True)
-        self.after(500, lambda: self.attributes("-topmost", False))
-        self.deiconify(); self.focus_force()
+        try: self.transient(master)
+        except: pass
+        self.lift()
+        self.attributes("-topmost", True)
+        self.after(600, lambda: self.attributes("-topmost", False))
+        self.deiconify()
+        self.grab_set()
+        self.focus_force()
 
-    def _create_stepper(self) -> None:
-        self.stepper_frame = ttk.Frame(self.content)
-        self.stepper_frame.pack(fill="x", pady=(0, 20))
-        self.stepper_frame.columnconfigure(0, weight=1)
-        self.stepper_frame.columnconfigure(1, weight=0)
-        self.stepper_frame.columnconfigure(2, weight=1)
-        self.stepper_frame.columnconfigure(3, weight=0)
-        self.stepper_frame.columnconfigure(4, weight=1)
+    # ---------- UI Teile ----------
+    def _build_stepper(self, parent, active:int):
+        # simple points 1..4 (nur 1 & 2 aktiv)
+        for w in parent.winfo_children(): w.destroy()
+        row = ttk.Frame(parent, style="Bg.TFrame"); row.pack()
+        for i,txt in enumerate(["1","2","3","4"], start=1):
+            dot = tk.Canvas(row, width=28, height=28, bg=DARK_BG, highlightthickness=0)
+            color = ACCENT2 if i <= active else "#2a3242"
+            dot.create_oval(4,4,24,24, fill=color, outline="")
+            dot.pack(side="left", padx=8)
+        # Linie(n) einfach weglassen – minimalistisch
 
-        self.step1 = _StepIndicator(self.stepper_frame, 1, "Connect Telegram")
-        self.connector = _StepConnector(self.stepper_frame)
-        self.step2 = _StepIndicator(self.stepper_frame, 2, "Select Chats")
+    def _build_step1(self, parent):
+        f = ttk.Frame(parent, style="Bg.TFrame")
+        card = ttk.Frame(f, style="Card.TFrame", padding=16); card.pack(fill="x", pady=8)
+        ttk.Label(card, text="Connect Telegram", style="H2.TLabel").pack(anchor="w", pady=(0,8))
 
-        self.step1.grid(row=0, column=0, sticky="n", padx=10)
-        self.connector.grid(row=0, column=2, sticky="we")
-        self.step2.grid(row=0, column=4, sticky="n", padx=10)
+        frm = ttk.Frame(card, style="Card.TFrame"); frm.pack(fill="x")
+        ttk.Label(frm, text="API ID", style="Muted.TLabel").grid(row=0, column=0, sticky="w")
+        e1 = ttk.Entry(frm, textvariable=self.api_id); e1.grid(row=1, column=0, sticky="ew", pady=(0,10))
+        ttk.Label(frm, text="API Hash", style="Muted.TLabel").grid(row=2, column=0, sticky="w")
+        e2 = ttk.Entry(frm, textvariable=self.api_hash, show="•"); e2.grid(row=3, column=0, sticky="ew")
+        frm.columnconfigure(0, weight=1)
 
-    def _create_steps(self) -> None:
-        self.api_id_var = tk.StringVar()
-        self.api_hash_var = tk.StringVar()
-        self.target_var = tk.StringVar()
-        self.forward_var = tk.StringVar()
+        nav = ttk.Frame(f, style="Bg.TFrame"); nav.pack(fill="x", pady=(12,0))
+        ttk.Button(nav, text="Weiter ▸", style="Nav.TButton", command=self._go_step2).pack(side="right")
+        ttk.Button(nav, text="Abbrechen", style="Nav.TButton", command=self._cancel).pack(side="left")
+        return f
 
-        self.api_id_var.trace_add("write", lambda *_: self._update_step1_state())
-        self.api_hash_var.trace_add("write", lambda *_: self._update_step1_state())
-        self.target_var.trace_add("write", lambda *_: self._update_step2_state())
-        self.forward_var.trace_add("write", lambda *_: self._update_step2_state())
+    def _build_step2(self, parent):
+        f = ttk.Frame(parent, style="Bg.TFrame")
+        self._build_stepper(self.stepper, 2)
 
-        self.step_container = ttk.Frame(self.content)
-        self.step_container.pack(fill="both", expand=True)
+        card = ttk.Frame(f, style="Card.TFrame", padding=16); card.pack(fill="both", expand=True, pady=8)
+        ttk.Label(card, text="Select Chats", style="H2.TLabel").pack(anchor="w", pady=(0,8))
 
-        self.step_frames = []
-        self._create_step1()
-        self._create_step2()
+        self.listbox = tk.Listbox(card, selectmode="browse", height=10, bg=CARD_BG, fg=TEXT_FG,
+                                  highlightthickness=0, relief="flat")
+        self.listbox.pack(fill="both", expand=True)
+        for c in _load_known_chats():
+            ident = c.get("username") or str(c.get("id",""))
+            self.listbox.insert("end", f"{c.get('title','Chat')}  ({ident})")
 
-    def _create_step1(self) -> None:
-        frame = ttk.Frame(self.step_container)
-        self.step_frames.append(frame)
+        hint = ttk.Label(card, text="Tipp: Liste wird aus chat_config.json geladen. "
+                                    "Später in der App unter „Chats“ aktualisieren.",
+                         style="Muted.TLabel")
+        hint.pack(anchor="w", pady=(6,0))
 
-        description = (
-            "Provide your Telegram API credentials. You can obtain them "
-            "from my.telegram.org."
-        )
-        ttk.Label(frame, text=description, wraplength=360, justify="left").grid(
-            row=0, column=0, columnspan=2, sticky="w", pady=(0, 15)
-        )
+        nav = ttk.Frame(f, style="Bg.TFrame"); nav.pack(fill="x", pady=(12,0))
+        ttk.Button(nav, text="◂ Zurück", style="Nav.TButton", command=self._go_step1).pack(side="left")
+        ttk.Button(nav, text="START BOT", style="Nav.TButton", command=self._finish).pack(side="right")
+        return f
 
-        ttk.Label(frame, text="API ID").grid(row=1, column=0, sticky="w")
-        vcmd = (frame.register(self._validate_api_id), "%P")
-        self.api_id_entry = ttk.Entry(frame, textvariable=self.api_id_var, validate="key", validatecommand=vcmd)
-        self.api_id_entry.grid(row=2, column=0, columnspan=2, sticky="we", pady=(0, 12))
-
-        ttk.Label(frame, text="API Hash").grid(row=3, column=0, sticky="w")
-        self.api_hash_entry = ttk.Entry(frame, textvariable=self.api_hash_var, show="*")
-        self.api_hash_entry.grid(row=4, column=0, columnspan=2, sticky="we", pady=(0, 12))
-
-        self.step1_buttons = ttk.Frame(frame)
-        self.step1_buttons.grid(row=5, column=0, columnspan=2, sticky="e", pady=(10, 0))
-
-        cancel_button = ttk.Button(self.step1_buttons, text="Cancel", command=self._cancel)
-        cancel_button.grid(row=0, column=0)
-
-        self.next_button = ttk.Button(
-            self.step1_buttons,
-            text="Next",
-            command=lambda: self._show_step(1),
-            state="disabled",
-            style="Accent.TButton",
-        )
-        self.next_button.grid(row=0, column=1, padx=(8, 0))
-
-        frame.columnconfigure(0, weight=1)
-
-    def _create_step2(self) -> None:
-        frame = ttk.Frame(self.step_container)
-        self.step_frames.append(frame)
-
-        ttk.Label(frame, text="Choose the chats for the bot.").grid(
-            row=0, column=0, columnspan=2, sticky="w", pady=(0, 15)
-        )
-
-        ttk.Label(frame, text="TG_TARGET").grid(row=1, column=0, sticky="w")
-        self.target_entry = ttk.Entry(frame, textvariable=self.target_var)
-        self.target_entry.grid(row=2, column=0, columnspan=2, sticky="we", pady=(0, 12))
-
-        ttk.Label(frame, text="FORWARD_TO (optional)").grid(row=3, column=0, sticky="w")
-        self.forward_entry = ttk.Entry(frame, textvariable=self.forward_var)
-        self.forward_entry.grid(row=4, column=0, columnspan=2, sticky="we", pady=(0, 12))
-
-        button_frame = ttk.Frame(frame)
-        button_frame.grid(row=5, column=0, columnspan=2, sticky="we", pady=(10, 0))
-        button_frame.columnconfigure(0, weight=1)
-
-        cancel_button = ttk.Button(button_frame, text="Cancel", command=self._cancel)
-        cancel_button.grid(row=0, column=0, sticky="w")
-
-        back_button = ttk.Button(button_frame, text="Back", command=lambda: self._show_step(0))
-        back_button.grid(row=0, column=1, padx=(8, 0))
-
-        self.start_button = ttk.Button(
-            button_frame,
-            text="Start Bot",
-            command=self._finish,
-            state="disabled",
-            style="Accent.TButton",
-        )
-        self.start_button.grid(row=0, column=2)
-
-        frame.columnconfigure(0, weight=1)
-
-    def _show_step(self, index: int) -> None:
-        self.current_step = index
-        for i, frame in enumerate(self.step_frames):
-            if i == index:
-                frame.pack(fill="both", expand=True)
-            else:
-                frame.pack_forget()
-
-        self.step1.set_state(active=index == 0, completed=index > 0)
-        self.step2.set_state(active=index == 1, completed=index > 1)
-        self.connector.set_state(active=index > 0)
-
-        if index == 0:
-            self.geometry("")
-            self.api_id_entry.focus_set()
+    # ---------- Navigation ----------
+    def _show(self, step:int):
+        for w in self.container.winfo_children(): w.forget()
+        if step == 1:
+            self.step1.pack(fill="both", expand=True)
+            self._build_stepper(self.stepper, 1)
         else:
-            self.geometry("")
-            self.target_entry.focus_set()
-        self.update_idletasks()
-        self._center_window()
-        self._update_step1_state()
-        self._update_step2_state()
+            self.step2.pack(fill="both", expand=True)
+            self._build_stepper(self.stepper, 2)
+        self.current = step
 
-    def _validate_api_id(self, proposed: str) -> bool:
-        return proposed.isdigit() or proposed == ""
+    def _go_step1(self):
+        self._show(1)
 
-    def _is_step1_valid(self) -> bool:
-        api_id = self.api_id_var.get().strip()
-        api_hash = self.api_hash_var.get().strip()
-        return api_id.isdigit() and bool(api_id) and bool(api_hash)
+    def _go_step2(self):
+        aid = self.api_id.get().strip()
+        ah  = self.api_hash.get().strip()
+        if not aid.isdigit() or not ah:
+            messagebox.showerror("Fehler", "Bitte gültige API ID (nur Ziffern) und API Hash eingeben.")
+            return
+        self._show(2)
 
-    def _is_step2_valid(self) -> bool:
-        target = self.target_var.get().strip()
-        return bool(target)
-
-    def _update_step1_state(self) -> None:
-        if self._is_step1_valid():
-            self.next_button.state(["!disabled"])
-        else:
-            self.next_button.state(["disabled"])
-
-    def _update_step2_state(self) -> None:
-        valid = self._is_step2_valid() and self._is_step1_valid()
-        if valid:
-            self.start_button.state(["!disabled"])
-        else:
-            self.start_button.state(["disabled"])
-
-    def _cancel(self) -> None:
+    def _cancel(self):
         self.result = None
-        self.grab_release()
+        try: self.grab_release()
+        except: pass
         self.destroy()
 
-    def _finish(self) -> None:
-        if not (self._is_step1_valid() and self._is_step2_valid()):
-            return
+    def _finish(self):
+        # Zielchat aus Auswahl extrahieren
+        sel = self.listbox.curselection()
+        target = ""
+        if sel:
+            text = self.listbox.get(sel[0])
+            if "(" in text and ")" in text:
+                target = text.split("(")[-1].rstrip(")")
 
-        config = {
-            "api_id": self.api_id_var.get().strip(),
-            "api_hash": self.api_hash_var.get().strip(),
-            "tg_target": self.target_var.get().strip(),
-            "forward_to": self.forward_var.get().strip(),
+        # Ergebnis setzen -> Caller speichert .env/ENV
+        self.result = {
+            "api_id":   int(self.api_id.get().strip()),
+            "api_hash": self.api_hash.get().strip(),
+            "tg_target": target.strip()
         }
-
-        try:
-            lines = [
-                f"TG_API_ID={config['api_id']}",
-                f"TG_API_HASH={config['api_hash']}",
-                f"TG_TARGET={config['tg_target']}",
-            ]
-            if config["forward_to"]:
-                lines.append(f"FORWARD_TO={config['forward_to']}")
-            Path(".env").write_text("\n".join(lines) + "\n", encoding="utf-8")
-        except OSError as exc:
-            messagebox.showerror("Error", f"Failed to write .env file: {exc}")
-            return
-
-        self.result = config
-        self.grab_release()
+        try: self.grab_release()
+        except: pass
         self.destroy()
 
-    def _center_window(self) -> None:
-        self.update_idletasks()
-        width = self.winfo_width()
-        height = self.winfo_height()
-        screen_width = self.winfo_screenwidth()
-        screen_height = self.winfo_screenheight()
-
-        x = max((screen_width // 2) - (width // 2), 0)
-        y = max((screen_height // 2) - (height // 2), 0)
-        self.geometry(f"{width}x{height}+{x}+{y}")
-
-
+# --------- Start-API für Windows-Starter ---------
 def run_onboarding(root: tk.Tk | None = None):
-    """
-    Startet das Onboarding als modales Fenster.
-    - Wenn root None ist, wird eine eigene Tk-Mainloop gefahren (robust auf Windows).
-    - Gibt ein dict mit Credentials zurück oder None, wenn abgebrochen.
-    Erwartet, dass OnboardingTwoStep eine Eigenschaft .result setzt (dict/None)
-    und sich selbst zerstört, wenn der Benutzer fertig ist.
-    """
-
-    own_root = False
+    own = False
     if root is None:
         root = tk.Tk()
-        own_root = True
-
-    # Toplevel erstellen
+        own = True
     wiz = OnboardingTwoStep(root)
-
-    # Sichtbarkeit & Modalität erzwingen
-    wiz.update_idletasks()
-    w, h = wiz.winfo_reqwidth(), wiz.winfo_reqheight()
-    sw, sh = wiz.winfo_screenwidth(), wiz.winfo_screenheight()
-    x, y = max(0, (sw - w) // 2), max(0, (sh - h) // 2)
-    wiz.geometry(f"+{x}+{y}")
-    try:
-        wiz.transient(root)
-    except Exception:
-        pass
-    wiz.lift()
-    wiz.attributes("-topmost", True)
-    wiz.after(600, lambda: wiz.attributes("-topmost", False))
-    wiz.deiconify()
-    wiz.grab_set()
-    wiz.focus_force()
-
-    # Entweder eigene Mainloop oder blockierend warten
-    if own_root:
-        # root.mainloop() endet erst, wenn wiz zerstört wurde
+    if own:
         root.mainloop()
-        try:
-            root.destroy()
-        except Exception:
-            pass
+        try: root.destroy()
+        except: pass
     else:
         root.wait_window(wiz)
-
-    # Ergebnis vom Wizard
-    try:
-        return getattr(wiz, "result", None)
-    except Exception:
-        return None
+    return getattr(wiz, "result", None)


### PR DESCRIPTION
## Summary
- replace the Tkinter onboarding with a dark-themed two-step wizard for entering API credentials and selecting chats
- load chat options from chat_config.json when available and fall back to placeholders before returning the result for environment setup

## Testing
- python -m compileall ui/onboarding.py

------
https://chatgpt.com/codex/tasks/task_e_68d2b3c0d1e88332879b865e80782ad9