### PR TITLE
Add reset session flag and harden chat config handling

### DIFF
--- a/scripts/reset_session.bat
+++ b/scripts/reset_session.bat
@@ -1,0 +1,7 @@
+@echo on
+setlocal
+cd /d %~dp0\..
+del /f /q tg_session.session 2>nul
+del /f /q tg_session.session-journal 2>nul
+echo Telegram session deleted.
+pause


### PR DESCRIPTION
## Summary
- add a `--reset-session` startup flag that deletes the cached Telethon session to force number/code login
- load the chat configuration via a defensive helper that normalises entries and renames corrupt files instead of crashing
- provide a Windows batch helper for manually resetting the Telegram session files

## Testing
- python -m compileall TelegramCopier_Windows.py ui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d2e2e483d883328eb3cc2d0790d96f