### PR TITLE
fix: rely on module-level os/glob during onboarding reset

### DIFF
--- a/TelegramCopier_Windows.py
+++ b/TelegramCopier_Windows.py
@@ -16,7 +16,7 @@ from enum import Enum
 from typing import Optional, Dict, List, Awaitable, Tuple
 
 # >>> numpy/mt5 guard + onboarding bootstrap
-import os, sys, pathlib, traceback
+import os, sys, pathlib, traceback, time, glob
 
 # 1) NumPy-Guard (MT5 braucht NumPy 1.x)
 try:
@@ -73,8 +73,7 @@ def run_onboarding_if_needed():
 
     # Session-Datei auf Wunsch löschen -> zwingt Telethon zur Nummer/Code-Abfrage
     if reset_session:
-        import glob, os
-
+        # KEIN "import os" mehr hier!
         for p in glob.glob("tg_session.session*"):
             try:
                 os.remove(p)


### PR DESCRIPTION
## Summary
- import `glob` and `time` alongside the existing bootstrap modules at the top of `TelegramCopier_Windows.py`
- use the module-level `os`/`glob` imports when handling `--reset-session` and remove the local import statement

## Testing
- python -m compileall TelegramCopier_Windows.py

------
https://chatgpt.com/codex/tasks/task_e_68d2e6f759188332a51ea5d4e6f048bf